### PR TITLE
Fixes #30: Elasticsearch index must be lower case

### DIFF
--- a/diskover.py
+++ b/diskover.py
@@ -1161,6 +1161,10 @@ def parse_cli_args(indexname):
                         version="diskover v%s" % version,
                         help="Prints version and exits")
     args = parser.parse_args()
+    if args.index:
+        args.index = args.index.lower()
+    if args.index2:
+        args.index2 = args.index2.lower()
     return args
 
 


### PR DESCRIPTION
This is a quick fix, mangling the arguments passed. I think it is the most strait forward way. Let me know if you prefer exception handling only.