### PR TITLE
Windows support

### DIFF
--- a/diskover_bot_module.py
+++ b/diskover_bot_module.py
@@ -17,11 +17,18 @@ import argparse
 import os
 import hashlib
 import socket
-import pwd
-import grp
 import time
 import re
 import base64
+import platform
+
+try:
+    import pwd
+    import grp
+#except ImportError:
+#    import win32api
+#    import win32con
+#    import win32security
 
 import diskover_connections
 
@@ -402,16 +409,18 @@ def get_dir_meta(worker_name, path, cliargs, reindex_dict, statsembeded=False):
             owner = owners[uid]
         # not in cache
         else:
-            try:
-                owner = pwd.getpwuid(uid).pw_name.split('\\')
-                # remove domain before owner
-                if len(owner) == 2:
-                    owner = owner[1]
-                else:
-                    owner = owner[0]
             # if we can't find the owner's user name, use the uid number
-            except KeyError:
-                owner = uid
+            owner = uid
+            if not platform.system() == 'Windows':
+                try:
+                    owner = pwd.getpwuid(uid).pw_name.split('\\')
+                    # remove domain before owner
+                    if len(owner) == 2:
+                        owner = owner[1]
+                    else:
+                        owner = owner[0]
+                except KeyError:
+                    owner = uid
             # store it in cache
             if not uid in uids:
                 uids.append(uid)
@@ -423,16 +432,18 @@ def get_dir_meta(worker_name, path, cliargs, reindex_dict, statsembeded=False):
             group = groups[gid]
         # not in cache
         else:
-            try:
-                group = grp.getgrgid(gid).gr_name.split('\\')
-                # remove domain before group
-                if len(group) == 2:
-                    group = group[1]
-                else:
-                    group = group[0]
             # if we can't find the group name, use the gid number
-            except KeyError:
-                group = gid
+            group = gid
+            if not platform.system() == 'Windows':
+                try:
+                    group = grp.getgrgid(gid).gr_name.split('\\')
+                    # remove domain before group
+                    if len(group) == 2:
+                        group = group[1]
+                    else:
+                        group = group[0]
+                except KeyError:
+                    group = gid
             # store in cache
             if not gid in gids:
                 gids.append(gid)
@@ -552,16 +563,18 @@ def get_file_meta(worker_name, path, cliargs, reindex_dict, statsembeded=False):
             owner = owners[uid]
         # not in cache
         else:
-            try:
-                owner = pwd.getpwuid(uid).pw_name.split('\\')
-                # remove domain before owner
-                if len(owner) == 2:
-                    owner = owner[1]
-                else:
-                    owner = owner[0]
             # if we can't find the owner's user name, use the uid number
-            except KeyError:
-                owner = uid
+            owner = uid
+            if not platform.system() == 'Windows':
+                try:
+                    owner = pwd.getpwuid(uid).pw_name.split('\\')
+                    # remove domain before owner
+                    if len(owner) == 2:
+                        owner = owner[1]
+                    else:
+                        owner = owner[0]
+                except KeyError:
+                    owner = uid
             # store it in cache
             if not uid in uids:
                 uids.append(uid)
@@ -573,16 +586,18 @@ def get_file_meta(worker_name, path, cliargs, reindex_dict, statsembeded=False):
             group = groups[gid]
         # not in cache
         else:
-            try:
-                group = grp.getgrgid(gid).gr_name.split('\\')
-                # remove domain before group
-                if len(group) == 2:
-                    group = group[1]
-                else:
-                    group = group[0]
             # if we can't find the group name, use the gid number
-            except KeyError:
-                group = gid
+            group = gid
+            if not platform.system() == 'Windows':
+                try:
+                    group = grp.getgrgid(gid).gr_name.split('\\')
+                    # remove domain before group
+                    if len(group) == 2:
+                        group = group[1]
+                    else:
+                        group = group[0]
+                except KeyError:
+                    group = gid
             # store in cache
             if not gid in gids:
                 gids.append(gid)


### PR DESCRIPTION
This should work around the unavailable Python functions on Windows satisfactorily enough to get diskover working. My worker bot is still dying when trying to run it this way (or, at least, trying to die, and it can't send the signal it wants) like this, but it's not clear to me that's a Windows issue, redis may just be timing out for some reason (not sure why as I'm running the diskover-web stack from Docker).

    11:00:30 diskover_crawl: diskover_bot_module.scrape_tree_meta([('C:\\Users\\axfel\\Desktop\\diskover', ['.gitignore', 'CHANGELOG.md', 'diskover-bot-launcher.sh', 'diskover-gource.sh', 'diskover.cfg', 'diskover.cfg.sample', 'diskover.py', 'diskover_bot_module.py', 'diskover_connections.py', 'diskover_crawlbot.py', 'diskover_dupes.py', 'diskover_gource.py', 'diskover_qumulo.py', 'diskover_s3.py', 'diskover_socket_server.py', 'diskover_worker_bot.py', 'export.json', 'killredisconn.py', 'LICENSE', 'optimize_indices.sh', 'README.md', 'requirements.txt', '_config.yml']), ('C:\\Users\\axfel\\Desktop\\diskover\\plugins', ['README.md']), ('C:\\Users\\axfel\\Desktop\\diskover\\netdata', ['redisrq.chart.py', 'redisrq.conf']), ('C:\\Users\\axfel\\Desktop\\diskover\\__pycache__', ['diskover.cpython-35.pyc', 'diskover_bot_module.cpython-35.pyc', 'diskover_connections.cpython-35.pyc']), ('C:\\Users\\axfel\\Desktop\\diskover\\treewalk_client', ['diskover-treewalk-client.py', 'scandir.py']), ('C:\\Users\\axfel\\Desktop\\diskover\\docs', ['diskover-crawler-terminal-screenshot.png', 'diskover-diagram.png', 'diskover-diagram1-dark.png', 'diskover-diagram1.png', 'diskover-gource-screenshot.png', 'diskover-gource1-screenshot.png', 'diskover-workerbot-terminal-screenshot.png', 'diskover.png', 'kibana-dashboard-dupes-screenshot.png', 'kibana-dashboarddark-screenshot.png', 'kibana-dashboardlight-screenshot.png', 'kibana-graph-dupes-screenshot.png', 'kibana-graph-hardlinks-screenshot.png', 'sharesniffer.png']), ('C:\\Users\\axfel\\Desktop\\diskover\\.git\\objects', []), ('C:\\Users\\axfel\\Desktop\\diskover\\.git\\logs', ['HEAD']), ('C:\\Users\\axfel\\Desktop\\diskover\\.git\\objects\\pack', ['pack-8e47838fc1fa82a5c3ecc22ec34cb007a9347e1a.idx', 'pack-8e47838fc1fa82a5c3ecc22ec34cb007a9347e1a.pack']), ('C:\\Users\\axfel\\Desktop\\diskover\\.git\\info', ['exclude']), ('C:\\Users\\axfel\\Desktop\\diskover\\.git\\logs\\refs', []), ('C:\\Users\\axfel\\Desktop\\diskover\\docs\\_pages', ['amazon_web_services_logo_aws.jpg', 'docker_logo.png', 'heatmap.png', 'home.md', 'vmware_logo_1.png']), ('C:\\Users\\axfel\\Desktop\\diskover\\.git\\refs', []), ('C:\\Users\\axfel\\Desktop\\diskover\\.git\\hooks', ['applypatch-msg.sample', 'commit-msg.sample', 'post-update.sample', 'pre-applypatch.sample', 'pre-commit.sample', 'pre-push.sample', 'pre-rebase.sample', 'pre-receive.sample', 'prepare-commit-msg.sample', 'update.sample']), ('C:\\Users\\axfel\\Desktop\\diskover\\.git\\logs\\refs\\remotes', []), ('C:\\Users\\axfel\\Desktop\\diskover\\.git\\logs\\refs\\heads', ['master']), ('C:\\Users\\axfel\\Desktop\\diskover\\.git\\refs\\heads', ['master']), ('C:\\Users\\axfel\\Desktop\\diskover\\.git\\refs\\remotes', []), ('C:\\Users\\axfel\\Desktop\\diskover\\.git\\logs\\refs\\remotes\\origin', ['HEAD']), ('C:\\Users\\axfel\\Desktop\\diskover\\.git\\refs\\remotes\\origin', ['HEAD'])], {'mtime': 0, 'batchsize': 50, 'indexemptydirs': False, 'maxdepth': None, 'qumulo': False, 'autotag': False, 'adaptivebatch': True, 'maxdcdepth': None, 's3':None, 'debug': False, 'listentwc': False, 'quiet': False, 'gourcemt': False, 'index2': None, 'verbose': False, 'reindex': False, 'optimizeindex': True, 'gourcert': False, 'index': 'diskover-test', 'listplugins': False, 'crawlbot': False, 'rootdir': 'C:\\Users\\axfel\\Desktop\\diskover', 'minsize': 1, 'listen': False, 'finddupes': False, 'hotdirs': None, 'reindexrecurs': False, 'dircalcsonly': False, 'copytags': None}, {'directory': [], 'file': []}) (05f5caeb-2724-4166-907b-bcc287400e31)
    11:00:30 AttributeError: module 'signal' has no attribute 'SIGALRM'
    Traceback (most recent call last):
      File "C:\ProgramData\chocolatey\lib\python3\tools\lib\site-packages\rq\worker.py", line 792, in perform_job
        with self.death_penalty_class(timeout, JobTimeoutException):
      File "C:\ProgramData\chocolatey\lib\python3\tools\lib\site-packages\rq\timeouts.py", line 35, in __enter__
        self.setup_death_penalty()
      File "C:\ProgramData\chocolatey\lib\python3\tools\lib\site-packages\rq\timeouts.py", line 70, in setup_death_penalty
        signal.signal(signal.SIGALRM, self.handle_death_penalty)
    AttributeError: module 'signal' has no attribute 'SIGALRM'